### PR TITLE
Add instructions for pushing repository to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 A new Flutter project.
 
+## Repository notes
+
+This codebase already contains the initial commit with the starter Flutter files.
+Run `git log --oneline` to see the existing history and verify the baseline before
+adding new changes.
+
+## Pushing this project to GitHub
+
+If you have not pushed this codebase to your own GitHub repository yet, you can do
+so with the following steps:
+
+1. Create an empty repository on GitHub (do not add a README, .gitignore, or
+   license from the UI).
+2. Set the GitHub repository as your `origin` remote:
+   ```bash
+   git remote add origin https://github.com/<your-username>/<your-repo>.git
+   ```
+3. Push the current branch (for example, `main`) to GitHub:
+   ```bash
+   git push -u origin main
+   ```
+
+If the repository already has commits, Git will reject non–fast-forward pushes.
+Use `git pull --rebase origin main` to bring in any remote changes before pushing
+again, and configure a personal access token if prompted for authentication.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.


### PR DESCRIPTION
## Summary
- add a README section with step-by-step instructions to push the project to a GitHub repository
- include guidance for handling non–fast-forward pushes and authentication prompts

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b90fe94c83318aa336c35dabc574)